### PR TITLE
[new-rule] `no-default-import`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,28 @@ jobs:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn add typescript@2.8
       - run: yarn test
+  test2.9:
+    docker:
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
+      - run: yarn add typescript@2.9
+      - run: yarn test
+  test3.0:
+    docker:
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
+      - run: yarn add typescript@3.0
+      - run: yarn test
   testNext:
     docker:
       - image: circleci/node:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn add typescript@2.9
       - run: yarn test
-  test3.0:
+  testRc:
     docker:
       - image: circleci/node:6
     steps:
@@ -105,7 +105,7 @@ jobs:
           at: '.'
       - restore_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@3.0
+      - run: yarn add typescript@rc
       - run: yarn test
   testNext:
     docker:
@@ -140,6 +140,12 @@ workflows:
           requires:
             - build
       - test2.8:
+          requires:
+            - build
+      - test2.9:
+          requires:
+            - build
+      - testRc:
           requires:
             - build
       - testNext:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,63 @@
 Change Log
 ===
 
+v5.11.0
+---
+
+## :warning: Deprecations
+
+- [deprecation] [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) is deprecated because typescript now covers most of its functionality (#3919)
+
+## :tada: Features
+- [new-rule] [`file-name-casing`](https://palantir.github.io/tslint/rules/file-name-casing/) (#3978)
+- [new-fixer] Add fixer for [`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/) (#3615)
+- [new-fixer] Implemented fixer for [`member-ordering`](https://palantir.github.io/tslint/rules/member-ordering/) and added corresponding tests. (#3935)
+- [new-rule-option] Add whitelist for [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) (#3979)
+
+## :hammer_and_wrench: Bugfixes & enhancements
+
+- [bugfix] [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) Fixes false positives when using the destructuring syntax (#3761)  (#3876)
+- [bugfix] Fix Copyright: @license JSDoc tag was missing (#3879)
+- [bugfix] Fix missing newline at end of file (#3896)
+- [bugfix] allow-empty-functions option of [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) rule is now properly respecting empty methods (#3897)
+- [bugfix] [`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers/) - support for negative zero (#3903)
+- [bugfix] Handle tsconfig.json errors without using JSON.stringify (#3908)
+- [bugfix] Fix CI: [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) test failure; typescript@next failure (#4019)
+- [bugfix] Fix edge case in [`no-console`](https://palantir.github.io/tslint/rules/no-console/) rule (#4041)
+- [docs] Fix typos in the [`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/) rule docs. (#3886)
+- [docs] Updated [`prefer-while`](https://palantir.github.io/tslint/rules/prefer-while/) docs to be semantically correct (#3888)
+- [docs] Fix link to configuration page (#3891)
+- [docs] Fix docs typo (#3898)
+- [docs] Fix docs typo (#3910)
+- [enhancement] Turn on strictPropertyInitialization for src/ and test/ (#3924)
+- [enhancement] Use Buffer.allocUnsafe instead of the deprecated new Buffer() (#3985)
+- [enhancement] Improve [`radix`](https://palantir.github.io/tslint/rules/radix/) rule checks (#3901)
+- [enhancement] Output +/- on diff so added/removed empty lines are visible. (#3973)
+- [rule-change] [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) now always considers peer dependencies (#3875)
+
+Thanks to our contributors!
+
+- Bowen Ni
+- Peter Safranek
+- Saugat Acharya
+- Jason Mendes
+- Ryan Waskiewicz
+- Dariusz Rumiński
+- Xinhu Liu
+- Rado Kirov
+- aervin_
+- Josh Goldberg
+- mertdeg2
+- Jason Killian
+- Adrian Leonhard
+- david-cannady
+- Andy Russell
+- Tibor Blenessy
+- Andrew Crites
+- Pavel Birukov
+- shalomdotnet
+
+
 v5.10.0
 ---
 

--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -44,6 +44,7 @@ Options:
 -r, --rules-dir [rules-dir]            rules directory
 -s, --formatters-dir [formatters-dir]  formatters directory
 -t, --format [format]                  output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)
+-q, --quiet                            hide non "error" severity linting errors from output
 --test                                 test that tslint produces the correct output for the specified directory
 -p, --project [project]                tsconfig.json file
 --type-check                           (deprecated) check for type errors before linting the project
@@ -116,6 +117,11 @@ tslint accepts the following command-line options:
     Other built-in options include pmd, msbuild, checkstyle, and vso.
     Additional formatters can be added and used if the --formatters-dir
     option is set.
+
+-q, --quiet
+    Hide non "error" severity linting errors from output. This can be
+    especially useful in CI environments, where you may want only "error"
+    severity linting errors to cause linting to fail.
 
 --test:
     Runs tslint on matched directories and checks if tslint outputs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "An extensible static analysis linter for the TypeScript language",
   "bin": {
     "tslint": "./bin/tslint"

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -153,6 +153,7 @@ export const rules = {
     "max-file-line-count": [true, 1000],
     "max-line-length": [true, 120],
     "no-default-export": true,
+    "no-default-import": true,
     "no-duplicate-imports": true,
     "no-irregular-whitespace": true,
     "no-mergeable-namespace": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,5 +47,6 @@ export interface ILinterOptions {
     fix: boolean;
     formatter?: string | FormatterConstructor;
     formattersDirectory?: string;
+    quiet?: boolean;
     rulesDirectory?: string | string[];
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -41,7 +41,7 @@ import { arrayify, dedent, flatMap, mapDefined } from "./utils";
  * Linter that can lint multiple files in consecutive runs.
  */
 export class Linter {
-    public static VERSION = "5.10.0";
+    public static VERSION = "5.11.0";
 
     public static findConfiguration = findConfiguration;
     public static findConfigurationPath = findConfigurationPath;

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -142,6 +142,9 @@ export class Linter {
     }
 
     public getResult(): LintResult {
+        const errors = this.failures.filter((failure) => failure.getRuleSeverity() === "error");
+        const failures = this.options.quiet ? errors : this.failures;
+
         const formatterName = this.options.formatter !== undefined ? this.options.formatter : "prose";
         const Formatter = findFormatter(formatterName, this.options.formattersDirectory);
         if (Formatter === undefined) {
@@ -149,16 +152,16 @@ export class Linter {
         }
         const formatter = new Formatter();
 
-        const output = formatter.format(this.failures, this.fixes);
+        const output = formatter.format(failures, this.fixes);
 
-        const errorCount = this.failures.filter((failure) => failure.getRuleSeverity() === "error").length;
+        const errorCount = errors.length;
         return {
             errorCount,
-            failures: this.failures,
+            failures,
             fixes: this.fixes,
             format: formatterName,
             output,
-            warningCount: this.failures.length - errorCount,
+            warningCount: failures.length - errorCount,
         };
     }
 

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -20,6 +20,7 @@ import * as ts from "typescript";
 
 import * as Lint from "../index";
 import { hasCommentAfterPosition } from "../language/utils";
+import { codeExamples } from "./code-examples/arrowReturnShorthand.examples";
 
 const OPTION_MULTILINE = "multiline";
 
@@ -45,6 +46,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         `,
         type: "style",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -20,6 +20,7 @@ import * as ts from "typescript";
 
 import * as Lint from "../index";
 import { isPascalCased } from "../utils";
+import { codeExamples } from "./code-examples/className.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -37,6 +38,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "style",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/code-examples/arrowReturnShorthand.examples.ts
+++ b/src/rules/code-examples/arrowReturnShorthand.examples.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "../../index";
+
+// tslint:disable: object-literal-sort-keys
+export const codeExamples = [
+    {
+        description: "Enforces usage of the shorthand return syntax when an arrow function's body does not span multiple lines.",
+        config: Lint.Utils.dedent`
+            "rules": { "arrow-return-shorthand": true }
+        `,
+        pass: Lint.Utils.dedent`
+            const calc = (x: number, y: number) => ({ add: x + y, sub: x - y, mul: x * y });
+            const calc2 = (x: number, y: number) => {
+                return { add: x + y, sub: x - y, mul: x * y }
+            };
+        `,
+        fail: Lint.Utils.dedent`
+            const calc = (x: number, y: number) => { return { add: x + y, sub: x - y, mul: x * y } };
+            const calc2 = (x: number, y: number) => {
+                return { add: x + y, sub: x - y, mul: x * y }
+            };
+       `,
+    },
+    {
+        description: "Enforces usage of the shorthand return syntax even when an arrow function's body spans multiple lines.",
+        config: Lint.Utils.dedent`
+            "rules": { "arrow-return-shorthand": [true, "multiline"] }
+        `,
+        pass: Lint.Utils.dedent`
+            const calc = (x: number, y: number) => ({ add: x + y, sub: x - y, mul: x * y });
+            const calc2 = (x: number, y: number) =>
+                ({ add: x + y, sub: x - y, mul: x * y });
+        `,
+        fail: Lint.Utils.dedent`
+            const calc = (x: number, y: number) => { return { add: x + y, sub: x - y, mul: x * y } };
+            const calc2 = (x: number, y: number) => {
+                return { add: x + y, sub: x - y, mul: x * y }
+            };
+       `,
+    },
+];

--- a/src/rules/code-examples/className.examples.ts
+++ b/src/rules/code-examples/className.examples.ts
@@ -20,23 +20,17 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Enforces PascalCased class and interface names.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "class-name": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            class MyClass { }
+            interface MyInterface { }
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
-        `,
+            class myClass { }
+            interface myInterface { }
+       `,
     },
 ];

--- a/src/rules/code-examples/noAny.examples.ts
+++ b/src/rules/code-examples/noAny.examples.ts
@@ -20,23 +20,15 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Disallows usages of `any` as a type declaration.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "no-any": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            let foo: object;
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
+            let foo: any;
         `,
     },
 ];

--- a/src/rules/code-examples/noEmptyInterface.examples.ts
+++ b/src/rules/code-examples/noEmptyInterface.examples.ts
@@ -20,23 +20,17 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Disallows empty interfaces.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "no-empty-interface": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
+            interface I {
+                foo: string;
             }
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
+            interface I { }
         `,
     },
 ];

--- a/src/rules/code-examples/noSparseArrays.examples.ts
+++ b/src/rules/code-examples/noSparseArrays.examples.ts
@@ -20,23 +20,15 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Disallows sparse arrays",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "no-sparse-arrays": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            const arr: string[] = ['elemenet1', 'element2'];
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
+            const arr: string[] = ['elemenet1',, 'element2'];
         `,
     },
 ];

--- a/src/rules/code-examples/noUnnecessaryCallbackWrapper.examples.ts
+++ b/src/rules/code-examples/noUnnecessaryCallbackWrapper.examples.ts
@@ -20,23 +20,19 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Disallows unnecessary callback wrappers",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "no-unnecessary-callback-wrapper": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            const handleContent = (content) => console.log('Handle content:', content);
+            const handleError = (error) => console.log('Handle error:', error);
+            promise.then(handleContent).catch(handleError);
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
+            const handleContent = (content) => console.log('Handle content:', content);
+            const handleError = (error) => console.log('Handle error:', error);
+            promise.then((content) => handleContent(content)).catch((error) => handleError(error));
         `,
     },
 ];

--- a/src/rules/code-examples/objectLiteralSortKeys.examples.ts
+++ b/src/rules/code-examples/objectLiteralSortKeys.examples.ts
@@ -20,53 +20,54 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Require curly braces whenever possible (default)",
+        description: "Requires that an object literal's keys be sorted alphabetically.",
         config: Lint.Utils.dedent`
-            "rules": { "curly": true }
+            "rules": { "object-literal-sort-keys": true }
         `,
         pass: Lint.Utils.dedent`
-            if (x > 0) {
-                doStuff();
-            }
+            let o = {
+                bar: 2,
+                foo: 1
+            };
         `,
         fail: Lint.Utils.dedent`
-            if (x > 0)
-                doStuff();
-
-            if (x > 0) doStuff();
+            let o = {
+                foo: 1,
+                bar: 2
+            };
         `,
     },
     {
-        description: "Make an exception for single-line instances",
+        description: Lint.Utils.dedent`Requires that an object literal's keys be sorted by interface-definition.
+            If there is no interface fallback to alphabetically.`,
         config: Lint.Utils.dedent`
-            "rules": { "curly": [true, "ignore-same-line"] }
+            "rules": {
+                "object-literal-sort-keys": {
+                    "options": "match-declaration-order"
+                }
+            }
         `,
         pass: Lint.Utils.dedent`
-            if (x > 0) doStuff();
-        `,
-        fail: Lint.Utils.dedent`
-            if (x > 0)
-                doStuff()
-        `,
-    },
-    {
-        description: "Error on unnecessary curly braces",
-        config: Lint.Utils.dedent`
-            "rules": { "curly": [true, "as-needed"] }
-        `,
-        pass: Lint.Utils.dedent`
-            if (x > 0)
-                doStuff();
+            interface I {
+                foo: number;
+                bar: number;
+            }
 
-            if (x > 0) {
-                customerUpdates.push(getInfo(customerId));
-                return customerUpdates;
-            }
+            let o: I = {
+                foo: 1,
+                bar: 2
+            };
         `,
         fail: Lint.Utils.dedent`
-            if (x > 0) {
-                doStuff();
+            interface I {
+                foo: number;
+                bar: number;
             }
+
+            let o: I = {
+                bar: 2,
+                foo: 1
+            };
         `,
     },
 ];

--- a/src/rules/code-examples/oneVariablePerDeclaration.examples.ts
+++ b/src/rules/code-examples/oneVariablePerDeclaration.examples.ts
@@ -20,22 +20,26 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Disallows multiple variable definitions in the same declaration statement.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "one-variable-per-declaration": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            const foo = 1;
+            const bar = '2';
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
+            const foo = 1, bar = '2';
+       `,
+    },
+    {
+        description: "Disallows multiple variable definitions in the same declaration statement but allows them in for-loops.",
+        config: Lint.Utils.dedent`
+            "rules": { "one-variable-per-declaration": [true, "ignore-for-loop"] }
+        `,
+        pass: Lint.Utils.dedent`
+            for (let i = 0, j = 10; i < 10; i++) {
+                doSomething(j, i);
             }
         `,
     },

--- a/src/rules/code-examples/onlyArrowFunctions.examples.ts
+++ b/src/rules/code-examples/onlyArrowFunctions.examples.ts
@@ -20,23 +20,23 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Disallows functions with the function keyword",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "only-arrow-functions": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            const myFunc = () => {
+                // do something ...
+            };
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
+            function myFunc() {
+                // do something ...
+            };
+
+            const myFunc = function() {
+                // do something ...
+            };
         `,
     },
 ];

--- a/src/rules/code-examples/preferTemplate.examples.ts
+++ b/src/rules/code-examples/preferTemplate.examples.ts
@@ -20,53 +20,36 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Require curly braces whenever possible (default)",
+        description: "Enforces the use of template strings whenever possible.",
         config: Lint.Utils.dedent`
-            "rules": { "curly": true }
+            "rules": { "prefer-template": true }
         `,
         pass: Lint.Utils.dedent`
-            if (x > 0) {
-                doStuff();
-            }
+            const x: number = 1;
+            const y: number = 1;
+            const myString: string = \`\${x} is equals \${y}\`;
         `,
         fail: Lint.Utils.dedent`
-            if (x > 0)
-                doStuff();
-
-            if (x > 0) doStuff();
+            const x: number = 1;
+            const y: number = 1;
+            const myString: string = x + ' is equals ' + y;
         `,
     },
     {
-        description: "Make an exception for single-line instances",
+        description: "Enforces the use of template strings, but allows up to one concatenation.",
         config: Lint.Utils.dedent`
-            "rules": { "curly": [true, "ignore-same-line"] }
+            "rules": { "prefer-template": [true, "allow-single-concat"] }
         `,
         pass: Lint.Utils.dedent`
-            if (x > 0) doStuff();
+            const x: number = 1;
+            const y: number = 1;
+            const myString: string = x + ' is equals 1';
+            const myString: string = \`\${x} is equals \${y}\`;
         `,
         fail: Lint.Utils.dedent`
-            if (x > 0)
-                doStuff()
-        `,
-    },
-    {
-        description: "Error on unnecessary curly braces",
-        config: Lint.Utils.dedent`
-            "rules": { "curly": [true, "as-needed"] }
-        `,
-        pass: Lint.Utils.dedent`
-            if (x > 0)
-                doStuff();
-
-            if (x > 0) {
-                customerUpdates.push(getInfo(customerId));
-                return customerUpdates;
-            }
-        `,
-        fail: Lint.Utils.dedent`
-            if (x > 0) {
-                doStuff();
-            }
+            const x: number = 1;
+            const y: number = 1;
+            const myString: string = x + ' is equals ' + y;
         `,
     },
 ];

--- a/src/rules/code-examples/radix.examples.ts
+++ b/src/rules/code-examples/radix.examples.ts
@@ -20,23 +20,21 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Requires the inclusion of the radix parameter when calling `parseInt`.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "radix": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
-            }
+            const x: string = '11';
+            const dec: number = parseInt(x, 10);
+            const bin: number = parseInt(x, 2);
+            const hex: number = parseInt(x, 16);
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
-            }
+            const x: string = '11';
+            const dec: number = parseInt(x);
+            const bin: number = parseInt(x, 2);
+            const hex: number = parseInt(x, 16);
         `,
     },
 ];

--- a/src/rules/code-examples/switchDefault.examples.ts
+++ b/src/rules/code-examples/switchDefault.examples.ts
@@ -20,22 +20,33 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Requires a `default` case in `switch` statements.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "switch-default": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
+            let foo: number = 1;
+            switch (foo) {
+                case 1:
+                    doSomething();
+                    break;
+                case 2:
+                    doSomething2();
+                    break;
+                default:
+                    console.log('default');
+                    break;
             }
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
+            let foo: number = 1;
+            switch (foo) {
+                case 1:
+                    doSomething();
+                    break;
+                case 2:
+                    doSomething2();
+                    break;
             }
         `,
     },

--- a/src/rules/code-examples/typedef.examples.ts
+++ b/src/rules/code-examples/typedef.examples.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "../../index";
+
+// tslint:disable: object-literal-sort-keys
+export const codeExamples = [
+    {
+        description: "Requires type definitions for call signatures",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "call-signature"] }
+        `,
+        pass: Lint.Utils.dedent`
+            function add(x, y): number {
+                return x + y;
+            }
+        `,
+        fail: Lint.Utils.dedent`
+            function add(x, y) {
+                return x + y;
+            }
+        `,
+    },
+    {
+        description: "Requires type definitions for arrow call signatures",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "arrow-call-signature"] }
+        `,
+        pass: Lint.Utils.dedent`
+            const add = (x, y): number => x + y;
+        `,
+        fail: Lint.Utils.dedent`
+            const add = (x, y) => x + y;
+        `,
+    },
+    {
+        description: "Requires type definitions for parameters",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "parameter"] }
+        `,
+        pass: Lint.Utils.dedent`
+            function add(x: number, y: number) {
+                return x + y;
+            }
+        `,
+        fail: Lint.Utils.dedent`
+            function add(x, y) {
+                return x + y;
+            }
+        `,
+    },
+    {
+        description: "Requires type definitions for arrow function parameters",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "arrow-parameter"] }
+        `,
+        pass: Lint.Utils.dedent`
+            const add = (x: number, y: number) => x + y;
+        `,
+        fail: Lint.Utils.dedent`
+            const add = (x, y) => x + y;
+        `,
+    },
+    {
+        description: "Requires type definitions for property declarations",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "property-declaration"] }
+        `,
+        pass: Lint.Utils.dedent`
+            interface I {
+                foo: number;
+                bar: string;
+            }
+    `,
+        fail: Lint.Utils.dedent`
+            interface I {
+                foo;
+                bar;
+            }
+        `,
+    },
+    {
+        description: "Requires type definitions for variable declarations",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "variable-declaration"] }
+        `,
+        pass: Lint.Utils.dedent`
+            let x: number;
+        `,
+        fail: Lint.Utils.dedent`
+            let x;
+        `,
+    },
+    {
+        description: "Requires type definitions for member variable declarations",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "member-variable-declaration"] }
+        `,
+        pass: Lint.Utils.dedent`
+            class MyClass {
+                x: number;
+            }
+        `,
+        fail: Lint.Utils.dedent`
+            class MyClass {
+                x;
+            }
+        `,
+    },
+    {
+        description: "Requires type definitions when destructuring objects.",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "object-destructuring"] }
+        `,
+        pass: Lint.Utils.dedent`
+            interface FooBar {
+                foo: number;
+                bar: string;
+            }
+            const foobar = { foo: 1, bar: '2' };
+            const { foo, bar }: FooBar = foobar;
+        `,
+        fail: Lint.Utils.dedent`
+            interface FooBar {
+                foo: number;
+                bar: string;
+            }
+            const foobar = { foo: 1, bar: '2' };
+            const { foo, bar } = foobar;
+        `,
+    },
+    {
+        description: "Requires type definitions when destructuring arrays.",
+        config: Lint.Utils.dedent`
+            "rules": { "typedef": [true, "array-destructuring"] }
+        `,
+        pass: Lint.Utils.dedent`
+            const foobar = [1, '2'];
+            const [foo, bar]: Array<number | string> = foobar;
+        `,
+        fail: Lint.Utils.dedent`
+            const foobar = [1, '2'];
+            const [foo, bar] = foobar;
+        `,
+    },
+];

--- a/src/rules/code-examples/useIsnan.examples.ts
+++ b/src/rules/code-examples/useIsnan.examples.ts
@@ -20,23 +20,19 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Flags throwing plain strings or concatenations of strings.",
+        description: "Enforces usage of `isNan()`.",
         config: Lint.Utils.dedent`
-            "rules": { "no-string-throw": true }
+            "rules": { "use-isnan": true }
         `,
         pass: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch (e) {
-                throw e;
+            if (isNaN(parseInt('_4711'))) {
+                doSomething();
             }
         `,
         fail: Lint.Utils.dedent`
-            try {
-                // ...
-            } catch {
-                throw 'There was a problem.';
+            if (parseInt('_4711') === NaN) {
+                doSomething();
             }
-        `,
+       `,
     },
 ];

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -107,7 +107,7 @@ const optionsDescription = Lint.Utils.dedent`
 
     ${namesMarkdown(PRESET_NAMES)}
 
-    Alternatively, the value for \`order\` maybe be an array consisting of the following strings:
+    Alternatively, the value for \`order\` may be an array consisting of the following strings:
 
     ${namesMarkdown(allMemberKindNames)}
 

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -18,6 +18,7 @@
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/noAny.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -41,6 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "typescript",
         typescriptOnly: true,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isCallExpression, isIdentifier, isPropertyAccessExpression } from "tsutils";
+import { isIdentifier, isPropertyAccessExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -48,13 +48,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<string[]>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
-        if (isCallExpression(node) &&
-            isPropertyAccessExpression(node.expression) &&
-            isIdentifier(node.expression.expression) &&
-            node.expression.expression.text === "console" &&
-            (ctx.options.length === 0 || ctx.options.indexOf(node.expression.name.text) !== -1)) {
+        if (isPropertyAccessExpression(node) &&
+            isIdentifier(node.expression) &&
+            node.expression.text === "console" &&
+            (ctx.options.length === 0 || ctx.options.indexOf(node.name.text) !== -1)) {
 
-            ctx.addFailureAtNode(node.expression, Rule.FAILURE_STRING_FACTORY(node.expression.name.text));
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(node.name.text));
         }
         return ts.forEachChild(node, cb);
     });

--- a/src/rules/noDefaultImportRule.ts
+++ b/src/rules/noDefaultImportRule.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isImportDeclaration, isNamedImports, isStringLiteral } from "tsutils";
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+const fromModulesConfigOptionName = "fromModules";
+interface RawConfigOptions {
+    [fromModulesConfigOptionName]: string;
+}
+interface Options {
+    [fromModulesConfigOptionName]: RegExp;
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-default-import",
+        description: "Disallows importing default members from certain ES6-style modules.",
+        descriptionDetails: "Import named members instead.",
+        rationale: Lint.Utils.dedent`
+            Named imports/exports [promote clarity](https://github.com/palantir/tslint/issues/1182#issue-151780453).
+            In addition, current tooling differs on the correct way to handle default imports/exports.
+            Avoiding them all together can help avoid tooling bugs and conflicts.
+
+            The rule supposed to narrow the scope of your changes in the case of monorepos.
+            Say, you have 20 packages and every removed default export from utility package would lead to changes
+            in each package, which might be harder to get merged by various reasons (harder to get your code approved
+            due to a number of required reviewers; longer build time due to a number of affected packages).
+            That's why "requires too many changes elsewhere" is a reason to ignore "no-default-export" rule.
+
+            Unlike "no-default-export", the rule requires you to make changes only in the package you work on
+            and the package you import from (unless the member you try to import already exported as a named one).`,
+        optionsDescription: "optionsDescription",
+        options: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    [fromModulesConfigOptionName]: { type: "string" },
+                },
+                required: [
+                    "fromModules",
+                ],
+            },
+        },
+        optionExamples: [
+            [true, { [fromModulesConfigOptionName]: "^palantir-|^_internal-*|^\\./|^\\.\\./" }],
+        ],
+        type: "maintainability",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Import of default members from this module is forbidden. Import named member instead";
+
+    public static getNamedDefaultImport(namedBindings: ts.NamedImports): ts.Identifier | null {
+        for (const importSpecifier of namedBindings.elements) {
+            if (importSpecifier.propertyName !== undefined && importSpecifier.propertyName.text === "default") {
+                return importSpecifier.propertyName;
+            }
+        }
+        return null;
+    }
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk, this.getRuleOptions(this.ruleArguments));
+    }
+    private isFromModulesConfigOption(option: boolean | RawConfigOptions): option is RawConfigOptions {
+        return typeof option === "object" && option[fromModulesConfigOptionName] !== undefined;
+    }
+    private getRuleOptions(options: ReadonlyArray<boolean | RawConfigOptions>): Options {
+        const fromModuleConfigOption = options.find<RawConfigOptions>(this.isFromModulesConfigOption);
+        if (fromModuleConfigOption !== undefined && typeof fromModuleConfigOption[fromModulesConfigOptionName] === "string") {
+            return {
+                [fromModulesConfigOptionName]: new RegExp(fromModuleConfigOption[fromModulesConfigOptionName]),
+            };
+        } else {
+            return {
+                [fromModulesConfigOptionName]: new RegExp("^\\./|^\\.\\./"),
+            };
+        }
+    }
+}
+
+function walk(ctx: Lint.WalkContext<Options>) {
+    if (ctx.sourceFile.isDeclarationFile || !ts.isExternalModule(ctx.sourceFile)) {
+        return;
+    }
+    for (const statement of ctx.sourceFile.statements) {
+        if (isImportDeclaration(statement)) {
+            const { importClause, moduleSpecifier } = statement;
+            if (
+                importClause !== undefined
+                && isStringLiteral(moduleSpecifier)
+                && ctx.options[fromModulesConfigOptionName].test(moduleSpecifier.text)
+            ) {
+                // module name matches specified in rule config
+                if (importClause.name !== undefined) {
+                    // `import Foo...` syntax
+                    const defaultImportedName = importClause.name;
+                    ctx.addFailureAtNode(defaultImportedName, Rule.FAILURE_STRING);
+                } else if (importClause.namedBindings !== undefined && isNamedImports(importClause.namedBindings)) {
+                    // `import { default...` syntax
+                    const defaultMember = Rule.getNamedDefaultImport(importClause.namedBindings);
+                    if (defaultMember !== null) {
+                        ctx.addFailureAtNode(defaultMember, Rule.FAILURE_STRING);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/rules/noEmptyInterfaceRule.ts
+++ b/src/rules/noEmptyInterfaceRule.ts
@@ -19,6 +19,7 @@ import { isInterfaceDeclaration } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/noEmptyInterface.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -30,6 +31,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: null,
         type: "typescript",
         typescriptOnly: true,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -51,15 +51,14 @@ function walk(ctx: Lint.WalkContext<void>) {
 
     function check(node: ts.StringLiteral): void {
         const text = node.getText(ctx.sourceFile);
-        const findTemplateStrings = /\\*\$\{/g;
+        const findTemplateStrings = /(\\*)(\$\{.+?\})/g;
         let instance = findTemplateStrings.exec(text);
         while (instance !== null) {
-            const matchLength = instance[0].length;
-            const backslashCount = matchLength - 2;
+            const backslashCount = instance[1].length;
             const instanceIsEscaped = backslashCount % 2 === 1;
             if (!instanceIsEscaped) {
                 const start = node.getStart() + (instance.index + backslashCount);
-                ctx.addFailureAt(start, 2, Rule.FAILURE_STRING);
+                ctx.addFailureAt(start, instance[2].length, Rule.FAILURE_STRING);
             }
             instance = findTemplateStrings.exec(text);
         }

--- a/src/rules/noSparseArraysRule.ts
+++ b/src/rules/noSparseArraysRule.ts
@@ -19,6 +19,7 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/noSparseArrays.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -31,6 +32,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "functionality",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/noUnnecessaryCallbackWrapperRule.ts
+++ b/src/rules/noUnnecessaryCallbackWrapperRule.ts
@@ -19,6 +19,7 @@ import { hasModifier, isArrowFunction, isCallExpression, isIdentifier, isSpreadE
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/noUnnecessaryCallbackWrapper.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -36,6 +37,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         `,
         type: "style",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -19,6 +19,7 @@ import { isInterfaceDeclaration, isObjectLiteralExpression, isSameLine, isTypeAl
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/objectLiteralSortKeys.examples";
 
 const OPTION_IGNORE_CASE = "ignore-case";
 const OPTION_MATCH_DECLARATION_ORDER = "match-declaration-order";
@@ -66,6 +67,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ],
         type: "maintainability",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/oneVariablePerDeclarationRule.ts
+++ b/src/rules/oneVariablePerDeclarationRule.ts
@@ -19,6 +19,7 @@ import { isForStatement, isVariableStatement } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/oneVariablePerDeclaration.examples";
 
 const OPTION_IGNORE_FOR_LOOP = "ignore-for-loop";
 
@@ -43,6 +44,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true, [true, OPTION_IGNORE_FOR_LOOP]],
         type: "style",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -19,6 +19,7 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/onlyArrowFunctions.examples";
 
 const OPTION_ALLOW_DECLARATIONS = "allow-declarations";
 const OPTION_ALLOW_NAMED_FUNCTIONS = "allow-named-functions";
@@ -47,6 +48,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true, [true, OPTION_ALLOW_DECLARATIONS, OPTION_ALLOW_NAMED_FUNCTIONS]],
         type: "typescript",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/preferTemplateRule.ts
+++ b/src/rules/preferTemplateRule.ts
@@ -19,6 +19,7 @@ import { isBinaryExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/preferTemplate.examples";
 
 const OPTION_SINGLE_CONCAT = "allow-single-concat";
 
@@ -40,6 +41,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true, [true, OPTION_SINGLE_CONCAT]],
         type: "style",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -21,14 +21,18 @@ import * as Lint from "../index";
 
 const OPTION_SINGLE = "single";
 const OPTION_DOUBLE = "double";
+const OPTION_BACKTICK = "backtick";
 const OPTION_JSX_SINGLE = "jsx-single";
 const OPTION_JSX_DOUBLE = "jsx-double";
 const OPTION_AVOID_TEMPLATE = "avoid-template";
 const OPTION_AVOID_ESCAPE = "avoid-escape";
 
+type QUOTE_MARK = "'" | '"' | "`";
+type JSX_QUOTE_MARK = "'" | '"';
+
 interface Options {
-    quoteMark: '"' | "'";
-    jsxQuoteMark: '"' | "'";
+    quoteMark: QUOTE_MARK;
+    jsxQuoteMark: JSX_QUOTE_MARK;
     avoidEscape: boolean;
     avoidTemplate: boolean;
 }
@@ -37,13 +41,14 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "quotemark",
-        description: "Requires single or double quotes for string literals.",
+        description: "Enforces quote character for string literals.",
         hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             Five arguments may be optionally provided:
 
             * \`"${OPTION_SINGLE}"\` enforces single quotes.
             * \`"${OPTION_DOUBLE}"\` enforces double quotes.
+            * \`"${OPTION_BACKTICK}"\` enforces backticks.
             * \`"${OPTION_JSX_SINGLE}"\` enforces single quotes for JSX attributes.
             * \`"${OPTION_JSX_DOUBLE}"\` enforces double quotes for JSX attributes.
             * \`"${OPTION_AVOID_TEMPLATE}"\` forbids single-line untagged template strings that do not contain string interpolations.
@@ -54,7 +59,15 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_SINGLE, OPTION_DOUBLE, OPTION_JSX_SINGLE, OPTION_JSX_DOUBLE, OPTION_AVOID_ESCAPE, OPTION_AVOID_TEMPLATE],
+                enum: [
+                    OPTION_SINGLE,
+                    OPTION_DOUBLE,
+                    OPTION_BACKTICK,
+                    OPTION_JSX_SINGLE,
+                    OPTION_JSX_DOUBLE,
+                    OPTION_AVOID_ESCAPE,
+                    OPTION_AVOID_TEMPLATE,
+                ],
             },
             minLength: 0,
             maxLength: 5,
@@ -74,11 +87,14 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const args = this.ruleArguments;
-        const quoteMark = getQuotemarkPreference(args) === OPTION_SINGLE ? "'" : '"';
+
+        const quoteMark = getQuotemarkPreference(args) ;
+        const jsxQuoteMark = getJSXQuotemarkPreference(args);
+
         return this.applyWithFunction(sourceFile, walk, {
             avoidEscape: hasArg(OPTION_AVOID_ESCAPE),
             avoidTemplate: hasArg(OPTION_AVOID_TEMPLATE),
-            jsxQuoteMark: hasArg(OPTION_JSX_SINGLE) ? "'" : hasArg(OPTION_JSX_DOUBLE) ? '"' : quoteMark,
+            jsxQuoteMark,
             quoteMark,
         });
 
@@ -97,6 +113,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 && isSameLine(sourceFile, node.getStart(sourceFile), node.end)) {
             const expectedQuoteMark = node.parent!.kind === ts.SyntaxKind.JsxAttribute ? options.jsxQuoteMark : options.quoteMark;
             const actualQuoteMark = sourceFile.text[node.end - 1];
+
             if (actualQuoteMark === expectedQuoteMark) {
                 return;
             }
@@ -104,38 +121,95 @@ function walk(ctx: Lint.WalkContext<Options>) {
             let fixQuoteMark = expectedQuoteMark;
 
             const needsQuoteEscapes = node.text.includes(expectedQuoteMark);
+
+            // This string requires escapes to use the expected quote mark, but `avoid-escape` was passed
             if (needsQuoteEscapes && options.avoidEscape) {
                 if (node.kind === ts.SyntaxKind.StringLiteral) {
                     return;
                 }
 
-                // If expecting double quotes, fix a template `a "quote"` to `a 'quote'` anyway,
-                // always preferring *some* quote mark over a template.
-                fixQuoteMark = expectedQuoteMark === '"' ? "'" : '"';
+                // If we are expecting double quotes, use single quotes to avoid
+                //   escaping. Otherwise, just use double quotes.
+                fixQuoteMark = expectedQuoteMark === '"' ?
+                    "'" :
+                    '"';
+
+                // It also includes the fixQuoteMark. Let's try to use single
+                //   quotes instead, unless we originally expected single
+                //   quotes, in which case we will try to use backticks. This
+                //   means that we may use backtick even with avoid-template
+                //   in trying to avoid escaping. What is the desired priority
+                //   here?
                 if (node.text.includes(fixQuoteMark)) {
-                    return;
+                    fixQuoteMark = expectedQuoteMark === "'" ?
+                        "`" :
+                        "'";
+
+                    // It contains all of the other kinds of quotes. Escaping is
+                    //   unavoidable, sadly.
+                    if (node.text.includes(fixQuoteMark)) {
+                        return;
+                    }
                 }
             }
 
             const start = node.getStart(sourceFile);
             let text = sourceFile.text.substring(start + 1, node.end - 1);
+
             if (needsQuoteEscapes) {
                 text = text.replace(new RegExp(fixQuoteMark, "g"), `\\${fixQuoteMark}`);
             }
+
             text = text.replace(new RegExp(`\\\\${actualQuoteMark}`, "g"), actualQuoteMark);
-            return ctx.addFailure(
-                start, node.end, Rule.FAILURE_STRING(actualQuoteMark, fixQuoteMark),
-                new Lint.Replacement(start, node.end - start, fixQuoteMark + text + fixQuoteMark));
+
+            return ctx.addFailure(start, node.end, Rule.FAILURE_STRING(actualQuoteMark, fixQuoteMark),
+                                  new Lint.Replacement(start, node.end - start, fixQuoteMark + text + fixQuoteMark));
         }
         ts.forEachChild(node, cb);
     });
 }
 
-function getQuotemarkPreference(args: any[]): string | undefined {
+function getQuotemarkPreference(args: any[]): QUOTE_MARK {
+    type QUOTE_PREF = typeof OPTION_SINGLE | typeof OPTION_DOUBLE | typeof OPTION_BACKTICK;
+
+    const quoteFromOption = {
+        [OPTION_SINGLE]: "'",
+        [OPTION_DOUBLE]: '"',
+        [OPTION_BACKTICK]: "`",
+    };
+
     for (const arg of args) {
-        if (arg === OPTION_SINGLE || arg === OPTION_DOUBLE) {
-            return arg as string;
+        switch (arg) {
+            case OPTION_SINGLE:
+            case OPTION_DOUBLE:
+            case OPTION_BACKTICK:
+                return quoteFromOption[arg as QUOTE_PREF] as QUOTE_MARK;
         }
     }
-    return undefined;
+
+    // Default to double quotes if no pref is found.
+    return '"';
+}
+
+function getJSXQuotemarkPreference(args: any[]): JSX_QUOTE_MARK {
+    type JSX_QUOTE_PREF = typeof OPTION_JSX_SINGLE | typeof OPTION_JSX_DOUBLE;
+
+    const jsxQuoteFromOption = {
+        [OPTION_JSX_SINGLE]: "'",
+        [OPTION_JSX_DOUBLE]: '"',
+    };
+
+    for (const arg of args) {
+        switch (arg) {
+            case OPTION_JSX_SINGLE:
+            case OPTION_JSX_DOUBLE:
+                return jsxQuoteFromOption[arg as JSX_QUOTE_PREF] as JSX_QUOTE_MARK;
+        }
+    }
+
+    // The JSX preference was not found, so try to use the regular preference.
+    //   If the regular pref is backtick, use double quotes instead.
+    const regularQuotemark = getQuotemarkPreference(args);
+
+    return regularQuotemark !== "`" ? regularQuotemark : '"';
 }

--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -19,6 +19,7 @@ import { isCallExpression, isIdentifier, isPropertyAccessExpression } from "tsut
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/radix.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -34,6 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "functionality",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -19,6 +19,7 @@ import { isDefaultClause } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/switchDefault.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -30,6 +31,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "functionality",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -19,6 +19,7 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/typedef.examples";
 
 interface Options {
     "call-signature"?: boolean;
@@ -90,6 +91,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [[true, OPTION_CALL_SIGNATURE, OPTION_PARAMETER, OPTION_MEMBER_VARIABLE_DECLARATION]],
         type: "typescript",
         typescriptOnly: true,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/useIsnanRule.ts
+++ b/src/rules/useIsnanRule.ts
@@ -19,6 +19,7 @@ import { isBinaryExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/useIsnan.examples";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -33,6 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "functionality",
         typescriptOnly: false,
+        codeExamples,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -90,6 +90,11 @@ export interface Options {
     project?: string;
 
     /**
+     * Whether to hide warnings
+     */
+    quiet?: boolean;
+
+    /**
      * Rules directory paths.
      */
     rulesDirectory?: string | string[];
@@ -241,9 +246,11 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
             fix: !!options.fix,
             formatter: options.format,
             formattersDirectory: options.formattersDirectory,
+            quiet: !!options.quiet,
             rulesDirectory: options.rulesDirectory,
         },
-        program);
+        program,
+    );
 
     let lastFolder: string | undefined;
     let configFile = options.config !== undefined ? findConfiguration(options.config).results : undefined;

--- a/src/tslintCli.ts
+++ b/src/tslintCli.ts
@@ -40,6 +40,7 @@ interface Argv {
     typeCheck?: boolean;
     test?: boolean;
     version?: boolean;
+    quiet?: boolean;
 }
 
 interface Option {
@@ -180,6 +181,13 @@ const options: Option[] = [
             type checker.`,
     },
     {
+        short: "q",
+        name: "quiet",
+        type: "boolean",
+        describe: "hide errors on lint",
+        description: "If true, hides warnings from linting output.",
+    },
+    {
         name: "type-check",
         type: "boolean",
         describe: "(deprecated) check for type errors before linting the project",
@@ -262,6 +270,7 @@ run(
         out: argv.out,
         outputAbsolutePaths: argv.outputAbsolutePaths,
         project: argv.project,
+        quiet: argv.quiet,
         rulesDirectory: argv.rulesDir,
         test: argv.test,
         typeCheck: argv.typeCheck,

--- a/test/linterTests.ts
+++ b/test/linterTests.ts
@@ -18,10 +18,10 @@
 import { assert } from "chai";
 import * as fs from "fs";
 import { createSourceFile, ScriptTarget } from "typescript";
+import { DEFAULT_CONFIG } from "../src/configuration";
 import { Replacement, RuleFailure } from "../src/language/rule/rule";
-import { createTempFile } from "./utils";
-
 import { Linter } from "../src/linter";
+import { createTempFile } from "./utils";
 
 class TestLinter extends Linter {
     public applyFixesHelper(fileName: string, source: string, ruleFailures: RuleFailure[]) {
@@ -49,6 +49,11 @@ const templateDeclarationFixed =
 <div></div>
 `;
 
+const withWarningDeclaration =
+`
+  console.log("This line will not pass linting with the default rule set");
+`;
+
 describe("Linter", () => {
 
     it("apply fixes to correct files", () => {
@@ -64,4 +69,39 @@ describe("Linter", () => {
         assert.equal(fs.readFileSync(templateFile, "utf-8"), templateDeclarationFixed);
     });
 
+    it("shows warnings", () => {
+        const config = DEFAULT_CONFIG;
+        config.rules.set("no-console", {
+            ruleArguments: ["log"],
+            ruleName: "no-console",
+            ruleSeverity: "warning",
+        });
+
+        const linter = new TestLinter({ fix: false });
+        const fileToLint = createTempFile("ts");
+        fs.writeFileSync(fileToLint, withWarningDeclaration);
+        linter.lint(fileToLint, withWarningDeclaration, config);
+        const result = linter.getResult();
+
+        assert.equal(result.warningCount, 1);
+        assert.equal(result.errorCount, 0);
+    });
+
+    it("does not show warnings when `quiet` is `true`", () => {
+        const config = DEFAULT_CONFIG;
+        config.rules.set("no-console", {
+            ruleArguments: ["log"],
+            ruleName: "no-console",
+            ruleSeverity: "warning",
+        });
+
+        const linter = new TestLinter({ fix: false, quiet: true });
+        const fileToLint = createTempFile("ts");
+        fs.writeFileSync(fileToLint, withWarningDeclaration);
+        linter.lint(fileToLint, withWarningDeclaration, config);
+        const result = linter.getResult();
+
+        assert.equal(result.warningCount, 0);
+        assert.equal(result.errorCount, 0);
+    });
 });

--- a/test/rules/no-console/all/test.ts.lint
+++ b/test/rules/no-console/all/test.ts.lint
@@ -16,5 +16,7 @@ console.something();
 ~~~~~~~~~~~~~~~~~           [err % ('something')]
 console.timeEnd();
 ~~~~~~~~~~~~~~~           [err % ('timeEnd')]
+[].forEach(console.log);
+           ~~~~~~~~~~~   [err % ('log')]
 
 [err]: Calls to 'console.%s' are not allowed.

--- a/test/rules/no-default-import/default/test.ts.lint
+++ b/test/rules/no-default-import/default/test.ts.lint
@@ -1,0 +1,36 @@
+import * as Utils from "tslint-utils"
+
+import TslintUtils from "tslint-utils"
+
+import Bar, { Foo } from "tslint-misc"
+
+import Bar, * as Foo from "tslint-misc"
+
+import { default as Foo } from "tslint-misc"
+
+import { default as foo, bar } from "tslint-misc"
+
+import { bar, default as foo } from "tslint-misc"
+
+import TslintUtils from "../tslint-utils"
+       ~~~~~~~~~~~ [0]
+
+import TslintUtils from "./tslint-utils"
+       ~~~~~~~~~~~ [0]
+
+import Bar, { Foo } from "../tslint-misc"
+       ~~~ [0]
+
+import Bar, * as Foo from "./tslint-misc"
+       ~~~ [0]
+
+import { default as Foo } from "../tslint-misc"
+         ~~~~~~~ [0]
+
+import { default as foo, bar } from "./tslint-misc"
+         ~~~~~~~ [0]
+
+import { bar, default as foo } from "../tslint-misc"
+              ~~~~~~~ [0]
+
+[0]: Import of default members from this module is forbidden. Import named member instead

--- a/test/rules/no-default-import/default/tslint.json
+++ b/test/rules/no-default-import/default/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-default-import": true
+  }
+}

--- a/test/rules/no-default-import/fromModules/test.ts.lint
+++ b/test/rules/no-default-import/fromModules/test.ts.lint
@@ -1,0 +1,24 @@
+import * as Utils from "tslint-utils"
+
+import TslintUtils from "../tslint-utils"
+       ~~~~~~~~~~~ [0]
+
+import TslintUtils from "tslint-utils"
+       ~~~~~~~~~~~ [0]
+
+import Bar, { Foo } from "tslint-misc"
+       ~~~ [0]
+
+import Bar, * as Foo from "tslint-misc"
+       ~~~ [0]
+
+import { default as Foo } from "tslint-misc"
+         ~~~~~~~ [0]
+
+import { default as foo, bar } from "tslint-misc"
+         ~~~~~~~ [0]
+
+import { bar, default as foo } from "tslint-misc"
+              ~~~~~~~ [0]
+
+[0]: Import of default members from this module is forbidden. Import named member instead

--- a/test/rules/no-default-import/fromModules/tslint.json
+++ b/test/rules/no-default-import/fromModules/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "no-default-import": [
+      true,
+      {
+        "fromModules": "^tslint-|^\\./|^\\.\\./"
+      }
+    ]
+  }
+}

--- a/test/rules/no-invalid-template-strings/test.ts.lint
+++ b/test/rules/no-invalid-template-strings/test.ts.lint
@@ -3,31 +3,39 @@ new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comme
 new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\${b}></div>',Tab.mixins.AlwaysHasData('\${c}'))))
 
 Tab.mixins.Templated('<div mbr-comment-tab=\${which}></div>',Tab.mixins.AlwaysHasData('\\${d}'))
-                                                                                         ~~ [0]
+                                                                                         ~~~~ [0]
 
 Tab.mixins.Templated(`<div mbr-comment-tab=\${e}></div>`,Tab.mixins.AlwaysHasData('${f}'))
-                                                                                   ~~ [0]
+                                                                                   ~~~~ [0]
 
 Tab.mixins.Templated('<div mbr-comment-tab=${g}></div>',Tab.mixins.AlwaysHasData('${h}'), Tab.mixin.SomeMethod('${i}'))
-                                           ~~ [0]
-                                                                                  ~~ [0]
-                                                                                                                ~~ [0]
+                                           ~~~~ [0]
+                                                                                  ~~~~ [0]
+                                                                                                                ~~~~ [0]
 
 new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\\${j}></div>',Tab.mixins.AlwaysHasData())))
-                                                                                         ~~ [0]
+                                                                                         ~~~~ [0]
 
 new (Tab.mixins.Templated('<div mbr-comment-tab=\\\\\${b}></div>',Tab.mixins.AlwaysHasData('\\\\${c}'))))
-                                                                                                ~~ [0]
+                                                                                                ~~~~ [0]
 
 "\${a} = ${a}";
-         ~~ [0]
+         ~~~~ [0]
 
 "One plus one is ${1 + 1}.";
-                 ~~ [0]
+                 ~~~~~~~~ [0]
 
 'One plus one is ${1 + 1}.';
-                 ~~ [0]
+                 ~~~~~~~~ [0]
 
 `One plus one is ${1 + 1}.`;
+
+"${";
+
+"${" + '}';
+
+"${() => {}} ${abc}"
+ ~~~~~~~~~~ [0]
+             ~~~~~~ [0]
 
 [0]: Interpolation will only work for template strings.

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -1,0 +1,9 @@
+var single = `single`;
+    var double = `married`;
+var singleWithinDouble = `'singleWithinDouble'`;
+var doubleWithinSingle = `"doubleWithinSingle"`;
+var tabNewlineWithinSingle = `tab\tNewline\nWithinSingle`;
+`escaped'quotemark`;
+
+// "avoid-template" option is not set.
+`foo`;

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -1,0 +1,15 @@
+var single = 'single';
+             ~~~~~~~~  [' should be `]
+    var double = "married";
+                 ~~~~~~~~~ [" should be `]
+var singleWithinDouble = "'singleWithinDouble'";
+                         ~~~~~~~~~~~~~~~~~~~~~~ [" should be `]
+var doubleWithinSingle = '"doubleWithinSingle"';
+                         ~~~~~~~~~~~~~~~~~~~~~~  [' should be `]
+var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be `]
+'escaped\'quotemark';
+~~~~~~~~~~~~~~~~~~~~ [' should be `]
+
+// "avoid-template" option is not set.
+`foo`;

--- a/test/rules/quotemark/backtick/tslint.json
+++ b/test/rules/quotemark/backtick/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "quotemark": [true, "backtick"]
+  }
+}


### PR DESCRIPTION
#### Overview of change:

As the `no-default-export`, the rule supposed to reduce usage of default imports/exports.

New rule supposed to narrow the scope of your changes in the case of medium-sized (and bigger) projects. Say, you have 20 packages and every removed default export from utility package would lead to changes in each package, which might be harder to get merged by various reasons (harder to get your code approved due to a number of required reviewers; longer build time due to a number of affected packages). That's why "requires too many changes elsewhere" is a reason why I see `no-default-export` ignored so often.

Unlike `no-default-export`, the rule requires you to make changes only in the package you work on and the package you import from (unless the member you try to import already exported as a named one).

It has a required config option where you have to specify packages you own, imports from which are to be checked.

#### CHANGELOG.md entry:

[new-rule] `no-default-import`